### PR TITLE
Add support for ePub footnotes

### DIFF
--- a/publish/epub.css
+++ b/publish/epub.css
@@ -1,0 +1,5 @@
+@import url("shared.css");
+
+.footnote-ref {
+    vertical-align: super;
+}

--- a/publish/options-epub.yaml
+++ b/publish/options-epub.yaml
@@ -1,4 +1,6 @@
 ---
 to: epub3
+css:
+  - ${.}/epub.css
 epub-title-page: false
 ...

--- a/publish/shared.css
+++ b/publish/shared.css
@@ -84,3 +84,8 @@ hr:after {
 	margin-top: 1rem;
 	margin-bottom: 1rem;
 }
+
+.footnote-ref {
+    line-height: 0;
+    font-size: 0.8em;
+}


### PR DESCRIPTION
Tweaked appearance of footnotes in PDFs to be smaller and keep the line height the same. For ePub, made footnotes small and superscript.

## PDF Before
<img width="510" height="107" alt="image" src="https://github.com/user-attachments/assets/250b3184-b11d-486f-aa29-391c00dfe6ff" />

## PDF After
<img width="519" height="102" alt="image" src="https://github.com/user-attachments/assets/356fe85c-26c0-41e2-bf27-f0372ce74505" />

