### PR TITLE
Fix Pandoc metadata handling and remove redundant shared.css imports

### DIFF
--- a/publish/build-book.py
+++ b/publish/build-book.py
@@ -744,7 +744,13 @@ all_formats = "all" in output_formats
 yaml_shared_path = os.path.join(os.path.dirname(this_script_path), "options-shared.yaml")
 # Final arg list will be: pre_args + (format-specific args, so settings/styles override properly) + post_args
 pandoc_pre_args = ['pandoc', f'--defaults={yaml_shared_path}']
-pandoc_post_args = [f'--metadata-file={full_metadata_path}', f'--metadata=date:"{meta_date}"', f'--metadata=date-year:"{meta_date_year}"', master_filename]
+# Use -M key=value for broad pandoc compatibility (some versions don't accept --metadata=key:"value")
+pandoc_post_args = [
+	f'--metadata-file={full_metadata_path}',
+	'-M', f'date={meta_date}',
+	'-M', f'date-year={meta_date_year}',
+	master_filename,
+]
 # Work around pandoc issue with not accepting css entries in metadata files.
 if "css" in json_contents:
 	extra_css = json_contents["css"]

--- a/publish/epub.css
+++ b/publish/epub.css
@@ -1,5 +1,3 @@
-@import url("shared.css");
-
 .footnote-ref {
     vertical-align: super;
 }

--- a/publish/pdf.css
+++ b/publish/pdf.css
@@ -1,8 +1,6 @@
 /* See MDN documentation on @page: https://developer.mozilla.org/en-US/docs/Web/CSS/page */
 /* See weasyprint documentation: https://doc.courtbouillon.org/weasyprint/stable/ */
 
-@import url("shared.css");
-
 @page {
 	size: 5in 8in;
 	@top-center { content: string(heading); font-size: 10pt; margin-top: 3mm; }


### PR DESCRIPTION
#  Summary

This PR fixes two Pandoc-related issues encountered during book publishing:

1. **Date metadata was not reliably applied** depending on the Pandoc version.
2. **Redundant CSS imports** caused warnings due to Pandoc already inlining `shared.css`.
